### PR TITLE
MultiBLAST Process Query: accommodate async report formatting

### DIFF
--- a/WSFPlugin/src/main/java/org/eupathdb/websvccommon/wsfplugin/blast/AbstractMultiBlastServicePlugin.java
+++ b/WSFPlugin/src/main/java/org/eupathdb/websvccommon/wsfplugin/blast/AbstractMultiBlastServicePlugin.java
@@ -115,6 +115,7 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
     // use passed params to POST new job request to blast service
     JSONObject newJobRequestJson = new JSONObject()
       .put("site", projectId)
+      .put("maxResultSize", 0)
       .put("maxSequences", 1)
       .put("isPrimary", false)
       .put("config", MultiBlastServiceParams.buildNewJobRequestConfigJson(request.getParams()))
@@ -145,13 +146,37 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
       ThreadUtil.sleep(POLLING_INTERVAL_MILLIS);
     }
 
-    // job complete; gather remaining prerequisites
+    // create a new "pairwise" report for this job
+    JSONObject newReportRequestJson = new JSONObject()
+      .put("jobID", jobId)
+      .put("format", "pairwise");
+
+    String reportId = createReport(newReportRequestJson, multiBlastServiceUrl, authHeader);
+
+    // keep going until report complete or max wait time expired
+    while (true) {
+
+      // query the report status (if results in cache, should return complete immediately)
+      if (isReportComplete(multiBlastServiceUrl, reportId, authHeader)) {
+        break;
+      }
+
+      // if max wait time reached, throw delayed result exception
+      if (t.getElapsed() > (MAX_WAIT_TIME_MILLIS)) {
+        throw new DelayedResultException();
+      }
+
+      // sleep until ready to poll again
+      ThreadUtil.sleep(POLLING_INTERVAL_MILLIS);
+    }
+
+    // job and report complete; gather remaining prerequisites
     RecordClass recordClass = PluginUtilities.getRecordClass(request);
     String dbType = request.getParams().get(MultiBlastServiceParams.BLAST_DATABASE_TYPE_PARAM_NAME);
     String[] orderedColumns = request.getOrderedColumns();
 
     // write results to plugin response
-    writeResults(multiBlastServiceUrl, jobId, authHeader, response, wdkModel, recordClass, dbType, orderedColumns);
+    writeResults(multiBlastServiceUrl, reportId, authHeader, response, wdkModel, recordClass, dbType, orderedColumns);
 
     return 0;
   }
@@ -167,29 +192,29 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
     }
   }
 
-  private void writeResults(String multiBlastServiceUrl, String jobId, TwoTuple<String,String> authHeader,
+  private void writeResults(String multiBlastServiceUrl, String reportId, TwoTuple<String,String> authHeader,
       PluginResponse response, WdkModel wdkModel, RecordClass recordClass,
       String dbType, String[] orderedColumns) throws PluginModelException, PluginUserException {
 
     // define request data
-    String jobReportEndpointUrl = multiBlastServiceUrl + "/jobs/" + jobId + "/report?format=pairwise&zip=false&inline=true";
+    String downloadReportUrl = multiBlastServiceUrl + "/reports/" + reportId + "/files/report.txt?download=false";
 
-    LOG.info("Requesting multi-blast job results at " + jobReportEndpointUrl);
+    LOG.info("Requesting multi-blast report results at " + downloadReportUrl);
 
     // make job report request
-    try (CloseableResponse jobReportResponse = ClientUtil.makeRequest(
-        jobReportEndpointUrl, HttpMethod.GET, Optional.empty(), new MapBuilder<String,String>(authHeader).toMap())) {
+    try (CloseableResponse downloadReportResponse = ClientUtil.makeRequest(
+        downloadReportUrl, HttpMethod.GET, Optional.empty(), new MapBuilder<String,String>(authHeader).toMap())) {
 
-      if (jobReportResponse.getStatus() != 200) {
+      if (downloadReportResponse.getStatus() != 200) {
         // error occurred; read entire body for error message
-        String responseBody = ClientUtil.readSmallResponseBody(jobReportResponse);
+        String responseBody = ClientUtil.readSmallResponseBody(downloadReportResponse);
         throw new PluginModelException("Unexpected response from multi-blast " +
-            "service while fetching job report (jobId=" + jobId + "): " +
-            jobReportResponse.getStatus() + FormatUtil.NL + responseBody);
+            "service while fetching report results (reportId=" + reportId + "): " +
+            downloadReportResponse.getStatus() + FormatUtil.NL + responseBody);
       }
 
       // request appears to be successful; read, parse and write result stream data into plugin response
-      try (InputStream resultStream = (InputStream)jobReportResponse.getEntity()) {
+      try (InputStream resultStream = (InputStream)downloadReportResponse.getEntity()) {
         String message = _resultFormatter.formatResult(response, orderedColumns, resultStream, recordClass, dbType, wdkModel);
         response.setMessage(message);
       }
@@ -202,7 +227,9 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
   /**
    * Makes a request to the multi-blast service to check the status of the job
    * with the passed ID.  Returns whether job is complete or still running. If
-   * job status is "error", throws a PluginModelException with the description.
+   * job status is "errored", throws a PluginModelException with the description.
+   *
+   * NOTE: If the job if found to be "expired", it will be rerun
    *
    * @param multiBlastServiceUrl blast service base URL
    * @param jobId job whose status to fetch
@@ -230,6 +257,9 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
         case "queued":
         case "in-progress":
           return false;
+        case "expired":
+          rerunJob(multiBlastServiceUrl, jobId, authHeader);
+          return false;
         case "completed":
           return true;
         case "errored":
@@ -238,6 +268,57 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
         default:
           throw new PluginModelException(
             "Multi-blast service job status endpoint returned unrecognized status value: " + responseObj.getString("status"));
+      }
+    }
+    catch (IOException e) {
+      throw new PluginModelException("Unable to read response body from service response.", e);
+    }
+  }
+
+  /**
+   * Makes a request to the multi-blast service to check the status of the report
+   * with the passed ID.  Returns whether report is complete or still running. If
+   * report status is "errored", throws a PluginModelException with the description.
+   *
+   * NOTE: If the report if found to be "expired", it will be rerun
+   *
+   * @param multiBlastServiceUrl blast service base URL
+   * @param reportId report whose status to fetch
+   * @return true if report is complete, else false (if still running)
+   * @throws PluginModelException if report has errored
+   */
+  private static boolean isReportComplete(String multiBlastServiceUrl, String reportId, TwoTuple<String,String> authHeader) throws PluginModelException {
+    String reportIdEndpointUrl = multiBlastServiceUrl + "/reports/" + reportId;
+    LOG.info("Requesting multi-blast report status at " + reportIdEndpointUrl);
+
+    // make job status request
+    try (CloseableResponse reportStatusResponse = ClientUtil.makeRequest(
+        reportIdEndpointUrl, HttpMethod.GET, Optional.empty(), new MapBuilder<String,String>(authHeader).toMap())) {
+
+      String responseBody = ClientUtil.readSmallResponseBody(reportStatusResponse);
+      if (reportStatusResponse.getStatus() != 200) {
+        throw new PluginModelException("Unexpected response from multi-blast " +
+            "service while checking report status (reportId=" + reportId + "): " +
+            reportStatusResponse.getStatus() + FormatUtil.NL + responseBody);
+      }
+
+      // parse response and analyze
+      JSONObject responseObj = new JSONObject(responseBody);
+      switch(responseObj.getString("status")) {
+        case "queued":
+        case "in-progress":
+          return false;
+        case "expired":
+          rerunReport(multiBlastServiceUrl, reportId, authHeader);
+          return false;
+        case "completed":
+          return true;
+        case "errored":
+          throw new PluginModelException(
+            "Multi-blast service report failed: " + responseObj.getString("description"));
+        default:
+          throw new PluginModelException(
+            "Multi-blast service report status endpoint returned unrecognized status value: " + responseObj.getString("status"));
       }
     }
     catch (IOException e) {
@@ -269,6 +350,69 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
       // other error
       throw new PluginModelException("Unexpected response from multi-blast " +
           "service while requesting new job: " + newJobResponse.getStatus() + NL + responseBody);
+    }
+    catch (IOException e) {
+      throw new PluginModelException("Unable to read response body from service response.", e);
+    }
+  }
+
+  private static String createReport(JSONObject newReportRequestBody, String multiBlastServiceUrl, TwoTuple<String,String> authHeader) throws PluginModelException {
+    String reportsEndpointUrl = multiBlastServiceUrl + "/reports";
+    LOG.info("Requesting new multi-blast report at " + reportsEndpointUrl + " with JSON body: " + newReportRequestBody.toString(2));
+
+    // make new job request
+    try (CloseableResponse newReportResponse = ClientUtil.makeRequest(
+        reportsEndpointUrl, HttpMethod.POST, Optional.of(newReportRequestBody), new MapBuilder<String,String>(authHeader).toMap())) {
+
+      String responseBody = ClientUtil.readSmallResponseBody(newReportResponse);
+
+      if (newReportResponse.getStatus() == 200) {
+        // success!  return report ID
+        return new JSONObject(responseBody).getString("reportID");
+      }
+
+      throw new PluginModelException("Unexpected response from multi-blast " +
+          "service while requesting new report: " + newReportResponse.getStatus() + NL + responseBody);
+    }
+    catch (IOException e) {
+      throw new PluginModelException("Unable to read response body from service response.", e);
+    }
+  }
+
+  private static void rerunJob(String multiBlastServiceUrl, String jobId, TwoTuple<String,String> authHeader) throws PluginModelException {
+    String jobsIdEndpointUrl = multiBlastServiceUrl + "/jobs/" + jobId;
+    LOG.info("Rerunning expired multi-blast job at " + jobsIdEndpointUrl + " with job id " + jobId);
+
+    // make new job request
+    try (CloseableResponse rerunJobResponse = ClientUtil.makeRequest(
+        jobsIdEndpointUrl, HttpMethod.POST, Optional.of(new JSONObject()), new MapBuilder<String,String>(authHeader).toMap())) {
+
+      String responseBody = ClientUtil.readSmallResponseBody(rerunJobResponse);
+
+      if (!rerunJobResponse.getStatusInfo().getFamily().equals(Family.SUCCESSFUL)) {
+        throw new PluginModelException("Unexpected response from multi-blast " +
+            "service while rerunning job: " + rerunJobResponse.getStatus() + NL + responseBody);
+      }
+    }
+    catch (IOException e) {
+      throw new PluginModelException("Unable to read response body from service response.", e);
+    }
+  }
+
+  private static void rerunReport(String multiBlastServiceUrl, String reportId, TwoTuple<String,String> authHeader) throws PluginModelException {
+    String reportsIdEndpointUrl = multiBlastServiceUrl + "/reports/" + reportId;
+    LOG.info("Rerunning expired multi-blast report at " + reportsIdEndpointUrl + " with report id " + reportId);
+
+    // make new job request
+    try (CloseableResponse rerunReportResponse = ClientUtil.makeRequest(
+        reportsIdEndpointUrl, HttpMethod.POST, Optional.of(new JSONObject()), new MapBuilder<String,String>(authHeader).toMap())) {
+
+      String responseBody = ClientUtil.readSmallResponseBody(rerunReportResponse);
+
+      if (!rerunReportResponse.getStatusInfo().getFamily().equals(Family.SUCCESSFUL)) {
+        throw new PluginModelException("Unexpected response from multi-blast " +
+            "service while rerunning report: " + rerunReportResponse.getStatus() + NL + responseBody);
+      }
     }
     catch (IOException e) {
       throw new PluginModelException("Unable to read response body from service response.", e);

--- a/WSFPlugin/src/main/java/org/eupathdb/websvccommon/wsfplugin/blast/AbstractMultiBlastServicePlugin.java
+++ b/WSFPlugin/src/main/java/org/eupathdb/websvccommon/wsfplugin/blast/AbstractMultiBlastServicePlugin.java
@@ -360,7 +360,7 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
     String reportsEndpointUrl = multiBlastServiceUrl + "/reports";
     LOG.info("Requesting new multi-blast report at " + reportsEndpointUrl + " with JSON body: " + newReportRequestBody.toString(2));
 
-    // make new job request
+    // make new report request
     try (CloseableResponse newReportResponse = ClientUtil.makeRequest(
         reportsEndpointUrl, HttpMethod.POST, Optional.of(newReportRequestBody), new MapBuilder<String,String>(authHeader).toMap())) {
 
@@ -383,7 +383,7 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
     String jobsIdEndpointUrl = multiBlastServiceUrl + "/jobs/" + jobId;
     LOG.info("Rerunning expired multi-blast job at " + jobsIdEndpointUrl + " with job id " + jobId);
 
-    // make new job request
+    // make rerun job request
     try (CloseableResponse rerunJobResponse = ClientUtil.makeRequest(
         jobsIdEndpointUrl, HttpMethod.POST, Optional.of(new JSONObject()), new MapBuilder<String,String>(authHeader).toMap())) {
 
@@ -403,7 +403,7 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
     String reportsIdEndpointUrl = multiBlastServiceUrl + "/reports/" + reportId;
     LOG.info("Rerunning expired multi-blast report at " + reportsIdEndpointUrl + " with report id " + reportId);
 
-    // make new job request
+    // make rerun report request
     try (CloseableResponse rerunReportResponse = ClientUtil.makeRequest(
         reportsIdEndpointUrl, HttpMethod.POST, Optional.of(new JSONObject()), new MapBuilder<String,String>(authHeader).toMap())) {
 

--- a/WSFPlugin/src/main/java/org/eupathdb/websvccommon/wsfplugin/blast/AbstractMultiBlastServicePlugin.java
+++ b/WSFPlugin/src/main/java/org/eupathdb/websvccommon/wsfplugin/blast/AbstractMultiBlastServicePlugin.java
@@ -116,6 +116,7 @@ public abstract class AbstractMultiBlastServicePlugin extends AbstractPlugin {
     JSONObject newJobRequestJson = new JSONObject()
       .put("site", projectId)
       .put("maxSequences", 1)
+      .put("isPrimary", false)
       .put("config", MultiBlastServiceParams.buildNewJobRequestConfigJson(request.getParams()))
       .put("targets", MultiBlastServiceParams.buildNewJobRequestTargetJson(request.getParams()));
 

--- a/WSFPlugin/src/main/java/org/eupathdb/websvccommon/wsfplugin/blast/MultiBlastServiceParams.java
+++ b/WSFPlugin/src/main/java/org/eupathdb/websvccommon/wsfplugin/blast/MultiBlastServiceParams.java
@@ -105,8 +105,6 @@ public class MultiBlastServiceParams {
     }
 
     if (selectedTool.equals("blastn")) {
-      var dustConfig = buildDustFilterConfig(filterLowComplexityRegions);
-
       var matchMismatchStr = getNormalizedParamValue(params, MATCH_MISMATCH_SCORE);
       var rewardPenaltyPair = paramValueToIntPair(matchMismatchStr);
       var reward = rewardPenaltyPair.getFirst();
@@ -115,7 +113,7 @@ public class MultiBlastServiceParams {
       return requestConfig
         .put("tool", selectedTool)
         .put("task", selectedTool)
-        .put("dust", dustConfig)
+        .put("dust", filterLowComplexityRegions ? "yes" : "no")
         .put("reward", reward)
         .put("penalty", penalty);
     }
@@ -123,10 +121,7 @@ public class MultiBlastServiceParams {
     var scoringMatrix = getNormalizedParamValue(params, SCORING_MATRIX_PARAM_NAME);
     requestConfig.put("matrix", scoringMatrix);
 
-    if (filterLowComplexityRegions) {
-      var enabledSegFilterConfig = buildEnabledSegFilterConfig();
-      requestConfig.put("seg", enabledSegFilterConfig);
-    }
+    requestConfig.put("seg", filterLowComplexityRegions ? "yes" : "no");
 
     if (selectedTool.equals("tblastx")) {
       return requestConfig
@@ -217,25 +212,6 @@ public class MultiBlastServiceParams {
     }
 
     return baseConfig;
-  }
-
-  private static JSONObject buildDustFilterConfig(boolean enable) {
-    var dustFilterConfig = new JSONObject().put("enable", enable);
-
-    if (enable) {
-      dustFilterConfig.put("level", 20);
-      dustFilterConfig.put("window", 64);
-      dustFilterConfig.put("linker", 1);
-    }
-
-    return dustFilterConfig;
-  }
-
-  private static JSONObject buildEnabledSegFilterConfig() {
-    return new JSONObject()
-      .put("window", 12)
-      .put("locut", 2.2)
-      .put("hicut", 2.5);
   }
 
   private static String getNormalizedParamValue(Map<String, String> params, String paramName) {


### PR DESCRIPTION
This PR updates the MultiBLAST process query to accommodate the [service](https://github.com/VEuPathDB/service-multi-blast)'s new "async" approach to generating reports.

In particular, the process query now:

1. Transforms the question param values into a valid BLAST job config
2. Creates a new BLAST job using that config
3. Polls the job until it is "complete" (if the job is found to have "expired," it will be rerun)
4. Creates a new pairwise report for the job
5. Polls the report until it is "complete" (if the report is found to have "expired," it will be rerun)
6. Retrieves the pairwise report and `write[s]Results` as usual

(Note: this PR serves as a record of the work that was needed to update the process query. In the interest of time, I will be self-merging. At some point, I would like to DRY up the implementation - there's a lot of similar code for job creation/polling/rerunning and report creation/polling/rerunning.)